### PR TITLE
Add support for Stripe payment method in checkout.

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods.js
+++ b/src/checkout/payment_methods/shop_payment_methods.js
@@ -1,9 +1,13 @@
 import { ShopPaymentMethod } from "./shop_payment_methods/shop_payment_method";
 import { BraintreeCreditCardShopPaymentMethod } from "./shop_payment_methods/braintree_credit_card_shop_payment_method";
+import { StripeCreditCardShopPaymentMethod } from "./shop_payment_methods/stripe_credit_card_shop_payment_method";
 
 const SHOP_PAYMENT_METHODS = {
   'braintree': {
     'credit-card': BraintreeCreditCardShopPaymentMethod
+  },
+  'stripe': {
+    'credit-card': StripeCreditCardShopPaymentMethod
   }
 };
 


### PR DESCRIPTION
Clubhouse: [ch7397](https://app.clubhouse.io/disco/story/7397)

### Description
Adds support for building a Stripe payment widget in checkout using Stripe.js' Elements functionality.

### Notes
* Not very resilient in terms of validation prior to submission, or collating additional billing information from the checkout to submit to Stripe.

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [x] Checked that this PR is referencing the correct base.