### PR TITLE
Allow Stripe configuration and passing customer ID as param

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods/stripe_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/stripe_credit_card_shop_payment_method.js
@@ -12,23 +12,30 @@ export class StripeCreditCardShopPaymentMethod extends ShopPaymentMethod {
       locale: this.options.shop.locale
     });
 
-    this.cardNumber = this.elements.create('cardNumber', {
-      style: this.getElementStyles(),
-      classes: this.getElementClasses()
-    });
+    this.cardNumber = this.elements.create(
+      'cardNumber',
+      Object.assign(this.getDefaultStyles(), this.options.stripe.elements.cardNumber)
+    );
     this.cardNumber.mount('#stripe-credit-card-card-number');
 
-    this.cardExpiry = this.elements.create('cardExpiry', {
-      style: this.getElementStyles(),
-      classes: this.getElementClasses()
-    });
+    this.cardExpiry = this.elements.create(
+      'cardExpiry',
+      Object.assign(this.getDefaultStyles(), this.options.stripe.elements.cardExpiry)
+    );
     this.cardExpiry.mount('#stripe-credit-card-expiration-date');
 
-    this.cardCvc = this.elements.create('cardCvc', {
-      style: this.getElementStyles(),
-      classes: this.getElementClasses()
-    });
+    this.cardCvc = this.elements.create(
+      'cardCvc',
+      Object.assign(this.getDefaultStyles(), this.options.stripe.elements.cardCvc)
+    );
     this.cardCvc.mount('#stripe-credit-card-cvv');
+  }
+
+  getDefaultStyles() {
+    return {
+      style: this.getElementStyles(),
+      classes: this.getElementClasses(),
+    }
   }
 
   getElementStyles() {

--- a/src/checkout/payment_methods/shop_payment_methods/stripe_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/stripe_credit_card_shop_payment_method.js
@@ -14,24 +14,24 @@ export class StripeCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
     this.cardNumber = this.elements.create(
       'cardNumber',
-      Object.assign(this.getDefaultStyles(), this.options.stripe.elements.cardNumber)
+      Object.assign(this.getDefaultConfig(), this.options.stripe.elements.cardNumber)
     );
     this.cardNumber.mount('#stripe-credit-card-card-number');
 
     this.cardExpiry = this.elements.create(
       'cardExpiry',
-      Object.assign(this.getDefaultStyles(), this.options.stripe.elements.cardExpiry)
+      Object.assign(this.getDefaultConfig(), this.options.stripe.elements.cardExpiry)
     );
     this.cardExpiry.mount('#stripe-credit-card-expiration-date');
 
     this.cardCvc = this.elements.create(
       'cardCvc',
-      Object.assign(this.getDefaultStyles(), this.options.stripe.elements.cardCvc)
+      Object.assign(this.getDefaultConfig(), this.options.stripe.elements.cardCvc)
     );
     this.cardCvc.mount('#stripe-credit-card-cvv');
   }
 
-  getDefaultStyles() {
+  getDefaultConfig() {
     return {
       style: this.getElementStyles(),
       classes: this.getElementClasses(),

--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -229,6 +229,7 @@ export class SubmarinePaymentMethodStep extends CustardModule {
 
   onPaymentMethodProcessingSuccess(payment_method_data) {
     payment_method_data.checkout_id = this.options.checkout.id;
+    payment_method_data.customer_id = this.options.customer.id;
     this.submarine.api.createPreliminaryPaymentMethod({ preliminary_payment_method: payment_method_data }, (result) => {
       if(result.success) {
         this.$form.attr('data-form-submarine-submit', 'ok');

--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -229,7 +229,7 @@ export class SubmarinePaymentMethodStep extends CustardModule {
 
   onPaymentMethodProcessingSuccess(payment_method_data) {
     payment_method_data.checkout_id = this.options.checkout.id;
-    payment_method_data.customer_id = this.options.customer.id;
+    payment_method_data.customer_id = this.options.customer && this.options.customer.id;
     this.submarine.api.createPreliminaryPaymentMethod({ preliminary_payment_method: payment_method_data }, (result) => {
       if(result.success) {
         this.$form.attr('data-form-submarine-submit', 'ok');


### PR DESCRIPTION
Clubhouse: [ch6535](https://app.clubhouse.io/disco/story/6535/customise-checkout-payment-step)

### Description
- Allows passing in a Stripe configuration object for the card number, expiry and CVC fields to allow for further customization. Options are to be passed to `window.custard.init()`. If provided, these will override the default configuration for each Stripe element. Example of a Stripe configuration object:
```
    stripe: {
      elements: {
        cardNumber: {
          placeholder: 'Card number'
        },
        cardExpiry: {
          placeholder: 'Expiration date (MM / YY)'
        },
        cardCvc: {
          placeholder: 'Security code'
        }
      }
    }
```
- Allows passing a Customer ID as a parameter to Submarine when creating a preliminary payment method. The customer object can be optionally passed to `window.custard.init()`. Example of a customer object:
```
    customer: {
      id: {{ customer.id | json }}
    }
```

### Notes
- Passing of the customer ID still remains to be fully tested once the related back-end code has been merged and deployed to staging.

Checklist
- [ ] Updated README and any other relevant documentation.
- [X]  Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [X]  Checked that this PR is referencing the correct base.