### PR TITLE
Handle submarine being the only payment gateway

### DIFF
--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -69,6 +69,13 @@ export class SubmarinePaymentMethodStep extends CustardModule {
 
     // Start the (asynchronous) loading of each payment method.
     this.loadPaymentMethods();
+
+    // If Submarine is the only payment gateway, select the first payment gateway option
+    this.$firstPaymentGatewayOption = this.$element.find('[data-select-payment-method]').first().find('label');
+
+    if (this.submarineIsOnlyPaymentGateway()) {
+      this.$firstPaymentGatewayOption.click();
+    }
   }
 
   setupSubmarine() {
@@ -143,7 +150,15 @@ export class SubmarinePaymentMethodStep extends CustardModule {
   onSubmarinePaymentMethodChange() {
     const $selectedSubmarinePaymentMethodInput = this.$element.find(`${SUBMARINE_PAYMENT_METHOD_INPUT_SELECTOR}:checked`);
     const $selectedSubmarinePaymentMethodElement = $selectedSubmarinePaymentMethodInput.closest('[data-select-payment-method]');
+    const $selectedShopifyGatewayElement = this.$element.find(`${SHOPIFY_GATEWAY_INPUT_SELECTOR}`).closest('[data-select-gateway]');
+
     this.selectedSubmarinePaymentMethod = $selectedSubmarinePaymentMethodElement.attr('data-select-payment-method');
+
+    // If Shopify payment gateways have been disabled and Submarine is the only payment gateway,
+    // be able to check if Submarine is the selected payment gateway
+    if (this.submarineIsOnlyPaymentGateway()) {
+      this.selectedShopifyGatewayId = $selectedShopifyGatewayElement.attr('data-select-gateway');
+    }
 
     // If a Submarine payment method was selected, ensure the Shopify Submarine gateway is selected under the hood.
     if(this.selectedSubmarinePaymentMethod !== undefined) {
@@ -169,6 +184,10 @@ export class SubmarinePaymentMethodStep extends CustardModule {
 
   submarineGatewayIsSelected() {
     return this.selectedShopifyGatewayId === this.options.submarine.submarine_gateway_id;
+  }
+
+  submarineIsOnlyPaymentGateway() {
+    return this.$element.find(`${SHOPIFY_GATEWAY_INPUT_SELECTOR}`).attr('type') === 'hidden';
   }
 
   sortGatewaysAndPaymentMethods() {


### PR DESCRIPTION
Clubhouse: [ch6535](https://app.clubhouse.io/disco/story/6535/customise-checkout-payment-step)

### Description
This PR fixes issues which surfaced in the iFit theme when the Shopify Script to disable the Shopify payment methods was published.

When all other Shopify payment gateway options are disabled via Shopify Scripts and Submarine is the only payment method available:

- None of the payment gateway options are selected by default on page load. The customer can still click 'Complete Order' (but will be redirected back with an error message).
<img width="596" alt="Screen Shot 2019-09-06 at 9 18 15 am" src="https://user-images.githubusercontent.com/18070175/64389778-64187e80-d087-11e9-8efd-c98acd30e827.png">

- When the Submarine payment gateway option is selected, the gateway subfields fail to appear. But when the Script is disabled, they appear as usual.
<img width="587" alt="Screen Shot 2019-09-06 at 9 18 40 am" src="https://user-images.githubusercontent.com/18070175/64389792-6ed31380-d087-11e9-9894-1f871cf26dc3.png">
 
Checklist
- [ ] Updated README and any other relevant documentation.
- [X]  Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [X]  Checked that this PR is referencing the correct base.