### PR TITLE
ch9284: Add additional expiry check for future dates

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods/cybersource_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/cybersource_credit_card_shop_payment_method.js
@@ -16,6 +16,8 @@ const CYBERSOURCE_CARD_TYPE_MAPPINGS = {
   forbrugsforeningen: null,
 };
 
+const MAXIMUM_FUTURE_EXPIRY_IN_YEARS = 15;
+
 export class CybersourceCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
   beforeSetup() {
@@ -66,7 +68,7 @@ export class CybersourceCreditCardShopPaymentMethod extends ShopPaymentMethod {
       },
       expiry: {
         value: expiry,
-        valid: payform.validateCardExpiry(expiry.month, expiry.year)
+        valid: this.isValidExpiry(expiry.month, expiry.year)
       },
       cvv: {
         value: cvv,
@@ -97,6 +99,16 @@ export class CybersourceCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
   isValidCardType(cardType) {
     return !!cardType && (['visa', 'mastercard', 'amex', 'discover'].indexOf(cardType) !== -1);
+  }
+
+  isValidExpiry(month, year) {
+    if(!payform.validateCardExpiry(month, year)) {
+      return false;
+    }
+
+    // Payform does not enforce any maximum future expiry, so we add our own here.
+    const currentYear = new Date().getFullYear();
+    return year < (currentYear + MAXIMUM_FUTURE_EXPIRY_IN_YEARS);
   }
 
   displayValidationErrors(state, errors) {


### PR DESCRIPTION
Clubhouse: [ch9284](https://app.clubhouse.io/disco/story/9284)

### Description
Adds an additional validation check on expiry dates, returning false if they are more than 15 years in the future. This appears consistent with maximum expiry date values [around the web](https://stackoverflow.com/questions/2500588/maximum-year-in-expiry-date-of-credit-card).

### Notes
* N/A

### Checklist
- [x] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.