### PR TITLE
Add dynamic payment method icon at Thank You step

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { Submarine } from './src/submarine';
-import { SubmarinePaymentMethodStep } from './src/checkout/submarine_payment_method_step';
+import { SubmarinePaymentMethodStep } from "./src/checkout/submarine_payment_method_step";
+import { SubmarineThankYouStep } from './src/checkout/submarine_thank_you_step';
 
-export { Submarine, SubmarinePaymentMethodStep };
+export { Submarine, SubmarinePaymentMethodStep, SubmarineThankYouStep };

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -1,0 +1,47 @@
+import { CustardModule, STEP_THANK_YOU, STEP_ORDER_STATUS } from "@discolabs/custard-js";
+
+export class SubmarineThankYouStep extends CustardModule {
+
+  id() {
+    return "submarine-thank-you-step";
+  }
+
+  steps() {
+    return [STEP_THANK_YOU, STEP_ORDER_STATUS];
+  }
+
+  selector() {
+    return ".main__content";
+  }
+
+  setup() {
+    this.updatePaymentMethodIcon();
+  }
+
+  updatePaymentMethodIcon() {
+    this.paymentIcon = this.$element.find(".payment-icon");
+    this.paymentIcon.removeClass("payment-icon--generic");
+    this.paymentIcon.addClass(`payment-icon--${this.iconName()}`);
+  }
+
+  iconName() {
+    const paymentMethod = this.options.order.attributes._payment_method;
+    const allPaymentMethods = [
+      ...this.options.submarine.shop_payment_methods.data,
+      ...this.options.submarine.customer_payment_methods.data
+    ];
+    const [paymentMethodName, paymentMethodId] = paymentMethod.split(/_(?=\d+$)/);
+    const paymentMethodData = allPaymentMethods.find(paymentMethod => {
+      return paymentMethod["type"] === paymentMethodName && Number(paymentMethod["id"]) === Number(paymentMethodId);
+    });
+
+    if (paymentMethodData["type"] === "shop_payment_method") {
+      const paymentMethodType = paymentMethodData.attributes.payment_method_type;
+      if (paymentMethodType === "credit-card") return "generic";
+      return paymentMethodType;
+    } else {
+      return paymentMethodData.attributes.payment_data.brand.replace(/\s+/g, "-").toLowerCase();
+    }
+  }
+
+}

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -19,9 +19,9 @@ export class SubmarineThankYouStep extends CustardModule {
   }
 
   updatePaymentMethodIcon() {
-    this.paymentIcon = this.$element.find(".payment-icon");
-    this.paymentIcon.removeClass("payment-icon--generic");
-    this.paymentIcon.addClass(`payment-icon--${this.iconName()}`);
+    this.$paymentIcon = this.$element.find(".payment-icon");
+    this.$paymentIcon.removeClass("payment-icon--generic");
+    this.$paymentIcon.addClass(`payment-icon--${this.iconName()}`);
   }
 
   iconName() {


### PR DESCRIPTION
Clubhouse: [ch9397](https://app.clubhouse.io/disco/story/9397/phase-2-applepay-client-uat-feedback)

### Description
This PR allows dynamic display of the card icon in the **Thank You/Order Status** steps of checkout. A new `SubmarineThankYouStep` class that inherits from `CustardModule` has been added which contains the logic for this feature.

This is done by updating the `payment-icon--generic` class on the payment icon element, e.g. `payment-icon--apple-pay` where `apple-pay` is the icon name.

The icon name is obtained using the following logic:

1. Get the payment method from the order attributes, e.g. `shop_payment_method_123` or `customer_payment_method_123`.
2. Split the payment method by the last underscore, resulting in `['shop_payment_method', '123']`
3. Find the payment method from a combined list of shop payment methods and customer payment methods.
4. Get the credit card brand from `paymentMethodData.attributes.payment_method_type` or `paymentMethodData.attributes.payment_data.brand` depending on whether a shop payment method or customer payment method was used to complete the transaction.

This means the order attributes need to be populated with the payment method. Also, the order attributes need to be added to the options argument when `custard.init()` is called in the theme.

The limitation of this approach is if a **shop payment method** is selected where the customer enters the credit card details, we won't be able to detect the card brand in that case and will instead fall back to the `generic` payment method icon. 

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.