### PR TITLE
Allow ordering of stored card payment methods

### DIFF
--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -214,9 +214,15 @@ export class SubmarinePaymentMethodStep extends CustardModule {
 
   getSortableElementSortIndex(sortableElement) {
     const $sortableElement = this.$(sortableElement);
-    const sortKey = $sortableElement.attr('data-select-gateway') || $sortableElement.attr('data-subfields-for-gateway') || $sortableElement.attr('data-select-payment-method') || $sortableElement.attr('data-subfields-for-payment-method');
-    const sortIndex = this.options.submarine.payment_method_sort_order.indexOf(sortKey);
-    return (sortIndex === -1) ? 999 : sortIndex;
+    const sortKey =
+      $sortableElement.attr("data-select-gateway") ||
+      $sortableElement.attr("data-subfields-for-gateway") ||
+      $sortableElement.attr("data-select-payment-method") ||
+      $sortableElement.attr("data-subfields-for-payment-method");
+    const sortIndex = this.options.submarine.payment_method_sort_order.findIndex(
+      paymentMethod => sortKey && sortKey.includes(paymentMethod)
+    );
+    return sortIndex === -1 ? 999 : sortIndex;
   }
 
   onFormSubmit(e) {


### PR DESCRIPTION
Clubhouse: [ch11314](https://app.clubhouse.io/disco/story/11314/phase-3-uat-feedback-theme-changes)

### Description
- At the moment, to place stored card payment methods (customer payment methods) at the top of the list of payment methods, we would need to specify it with the ID in the `submarine.payment_method_sort_order` metafield, e.g. `[customer_payment_method_123]`.
- The change in this PR allows us to place all customer payment methods at the top of the list by just specifying `[customer_payment_method]` in the `submarine.payment_method_sort_order` metafield.

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.