### PR TITLE
CH11314: Add ability to pass query params to get request

### DIFF
--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -61,7 +61,7 @@ const getMethodUrl = (api_url, method, context) => {
  * Return a querystring that can be appended to an API endpoint.
  *
  * @params params
- * @returns {object}
+ * @returns {string}
  */
 const buildQueryString = (params) => {
   const queryString = Object.keys(params)

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -107,8 +107,8 @@ export class ApiClient {
 
   execute(method, data, context, callback) {
     const url = getMethodUrl(this.api_url, method, context);
-    const queryParams = this.buildQueryParams(data, http_method);
     const http_method = getMethodHttpMethod(method);
+    const queryParams = this.buildQueryParams(data, http_method);
     const payload = getMethodPayload(http_method, data);
 
     return fetch(url + buildQueryString(queryParams), {

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -108,7 +108,7 @@ export class ApiClient {
   execute(method, data, context, callback) {
     const url = getMethodUrl(this.api_url, method, context);
     const http_method = getMethodHttpMethod(method);
-    const queryParams = this.buildQueryParams(data, http_method);
+    const queryParams = this.buildQueryParams(http_method, data);
     const payload = getMethodPayload(http_method, data);
 
     return fetch(url + buildQueryString(queryParams), {
@@ -125,7 +125,7 @@ export class ApiClient {
     });
   }
 
-  buildQueryParams(data, http_method) {
+  buildQueryParams(http_method, data) {
     return http_method === GET ? Object.assign(this.authentication, data) : this.authentication;
   }
 


### PR DESCRIPTION
Clubhouse: [ch11314](https://app.clubhouse.io/disco/story/11314/phase-3-uat-feedback-theme-changes)

### Description
- Adds ability to pass params as an object to a GET request to Submarine.
- First combines the authentication params with the new params and then converts them to a query string that can be tacked on to the end of the URL.
- `params` is the second argument after `callback` to avoid breaking existing code.

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.