### PR TITLE
Add duplicate subscription endpoint to API client

### DIFF
--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -20,6 +20,10 @@ const API_METHODS = {
     http_method: GET,
     endpoint: '/customers/{{ customer_id }}/subscriptions.json'
   },
+  duplicate_subscription: {
+    http_method: POST,
+    endpoint: '/customers/{{ customer_id }}/subscriptions/{{ id }}/duplicate.json'
+  },
   update_subscription: {
     http_method: PUT,
     endpoint: '/customers/{{ customer_id }}/subscriptions/{{ id }}.json'
@@ -154,6 +158,11 @@ export class ApiClient {
   cancelSubscription(id, callback) {
     const context = Object.assign({}, this.context, { id });
     return this.execute('cancel_subscription', {}, context, callback);
+  }
+
+  duplicateSubscription(id, callback) {
+    const context = Object.assign({}, this.context, { id });
+    return this.execute('duplicate_subscription', {}, context, callback);
   }
 
   generatePaymentProcessorClientToken(payment_processor, callback) {


### PR DESCRIPTION
Clubhouse: [ch11703](https://app.clubhouse.io/disco/story/11703/ability-to-view-cancelled-subscriptions-and-resume-any-one-of-them)

### Description
- Adds ability to call the `/customers/{{ customer_id }}/subscriptions/{{ id }}/duplicate.json` endpoint in Submarine to create a duplicate subscription.

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.