### PR TITLE
ch11860: Add Komoju credit card and Submarine bank transfer support

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods.js
+++ b/src/checkout/payment_methods/shop_payment_methods.js
@@ -4,6 +4,7 @@ import { BraintreeApplePayShopPaymentMethod } from "./shop_payment_methods/brain
 import { CybersourceCreditCardShopPaymentMethod } from "./shop_payment_methods/cybersource_credit_card_shop_payment_method";
 import { StripeCreditCardShopPaymentMethod } from "./shop_payment_methods/stripe_credit_card_shop_payment_method";
 import { KomojuCreditCardShopPaymentMethod } from "./shop_payment_methods/komoju_credit_card_payment_method";
+import { SubmarineBankTransferShopPaymentMethod } from "./shop_payment_methods/submarine_bank_transfer_payment_method";
 
 const SHOP_PAYMENT_METHODS = {
   'braintree': {
@@ -18,6 +19,9 @@ const SHOP_PAYMENT_METHODS = {
   },
   'komoju': {
     'credit-card': KomojuCreditCardShopPaymentMethod
+  },
+  'submarine': {
+    'bank-transfer': SubmarineBankTransferShopPaymentMethod
   }
 };
 

--- a/src/checkout/payment_methods/shop_payment_methods.js
+++ b/src/checkout/payment_methods/shop_payment_methods.js
@@ -3,6 +3,7 @@ import { BraintreeCreditCardShopPaymentMethod } from "./shop_payment_methods/bra
 import { BraintreeApplePayShopPaymentMethod } from "./shop_payment_methods/braintree_apple_pay_shop_payment_method";
 import { CybersourceCreditCardShopPaymentMethod } from "./shop_payment_methods/cybersource_credit_card_shop_payment_method";
 import { StripeCreditCardShopPaymentMethod } from "./shop_payment_methods/stripe_credit_card_shop_payment_method";
+import { KomojuCreditCardShopPaymentMethod } from "./shop_payment_methods/komoju_credit_card_payment_method";
 
 const SHOP_PAYMENT_METHODS = {
   'braintree': {
@@ -14,6 +15,9 @@ const SHOP_PAYMENT_METHODS = {
   },
   'stripe': {
     'credit-card': StripeCreditCardShopPaymentMethod
+  },
+  'komoju': {
+    'credit-card': KomojuCreditCardShopPaymentMethod
   }
 };
 

--- a/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
@@ -19,7 +19,8 @@ export class KomojuCreditCardShopPaymentMethod extends ShopPaymentMethod {
       locale: this.options.shop.locale,
       currency: this.options.shop.currency,
       title: this.options.shop.name,
-      methods: ["credit_card"]
+      methods: ["credit_card"],
+      prefillEmail: this.options.customer.email
     });
   }
 

--- a/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
@@ -20,7 +20,7 @@ export class KomojuCreditCardShopPaymentMethod extends ShopPaymentMethod {
       currency: this.options.shop.currency,
       title: this.options.shop.name,
       methods: ["credit_card"],
-      prefillEmail: this.options.customer && this.options.customer.email
+      prefillEmail: this.options.checkout.email
     });
   }
 

--- a/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
@@ -20,7 +20,7 @@ export class KomojuCreditCardShopPaymentMethod extends ShopPaymentMethod {
       currency: this.options.shop.currency,
       title: this.options.shop.name,
       methods: ["credit_card"],
-      prefillEmail: this.options.customer.email
+      prefillEmail: this.options.customer && this.options.customer.email
     });
   }
 

--- a/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
@@ -1,0 +1,40 @@
+import { ShopPaymentMethod } from './shop_payment_method';
+
+export class KomojuCreditCardShopPaymentMethod extends ShopPaymentMethod {
+
+  process(success) {
+    this.handler = Komoju.multipay.configure({
+      key: this.data.attributes.publishable_api_key,
+      token: token => success({
+        customer_payment_method_id: null,
+        payment_nonce: token.id,
+        payment_method_type: 'credit-card',
+        payment_processor: 'komoju'
+      })
+    });
+
+    this.handler.open({
+      amount: Number(this.options.checkout.total_price.replace(/,/g, '')),
+      endpoint: "https://komoju.com",
+      locale: this.options.shop.locale,
+      currency: this.options.shop.currency,
+      title: this.options.shop.name,
+      methods: ["credit_card"]
+    });
+  }
+
+  getRenderContext() {
+    return {
+      id: this.data.id,
+      title: this.t('payment_methods.shop_payment_methods.komoju.credit_card.title'),
+      value: this.getValue(),
+      subfields_content: this.options.html_templates.komoju_credit_card_subfields_content,
+      subfields_class: '',
+      icon: 'generic',
+      icon_description: this.t('payment_methods.shop_payment_methods.komoju.credit_card.icon_description'),
+      komoju_credit_card_message_js: this.t('payment_methods.shop_payment_methods.komoju.credit_card.komoju_credit_card_message_js'),
+      komoju_credit_card_message_no_js: this.t('payment_methods.shop_payment_methods.komoju.credit_card.komoju_credit_card_message_no_js')
+    }
+  }
+
+}

--- a/src/checkout/payment_methods/shop_payment_methods/submarine_bank_transfer_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/submarine_bank_transfer_payment_method.js
@@ -1,0 +1,28 @@
+import { ShopPaymentMethod } from './shop_payment_method';
+
+export class SubmarineBankTransferShopPaymentMethod extends ShopPaymentMethod {
+
+  process(success, error) {
+    success({
+      customer_payment_method_id: null,
+      payment_nonce: null,
+      payment_method_type: 'bank-transfer',
+      payment_processor: 'submarine'
+    });
+  }
+
+  getRenderContext() {
+    return {
+      id: this.data.id,
+      title: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.title'),
+      value: this.getValue(),
+      subfields_content: this.options.html_templates.submarine_bank_transfer_subfields_content,
+      subfields_class: '',
+      icon: 'generic',
+      icon_description: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.icon_description'),
+      submarine_bank_transfer_message_js: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.submarine_bank_transfer_message_js'),
+      submarine_bank_transfer_message_no_js: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.submarine_bank_transfer_message_no_js'),
+    }
+  }
+
+}


### PR DESCRIPTION
Clubhouse: [ch11860](https://app.clubhouse.io/disco/story/11860/add-credit-card-support-for-multipay-widget-in-submarine-js), [ch11861](https://app.clubhouse.io/disco/story/11861/add-bank-transfer-support-for-multipay-widget-in-submarine-js)

### Description
- Adds credit card support for Komoju MultiPay widget in Submarine.js.
- Adds bank transfer support through Submarine payment processor
- Adds ability to pre-fill the customer's address in Komoju's credit card widget ([see screen recording](https://drive.google.com/file/d/1vd9_MOoPvOtqUIYqMPxjQ2wrzhExyAHk/view?usp=sharing)). If `prefillEmail` is present, the email field will not show. If it has value `undefined`, the email field will automatically show. 

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.