### PR TITLE
CH12613: Client uat feedback

### DIFF
--- a/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
+++ b/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
@@ -46,9 +46,13 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
   }
 
   paypalRenderContext() {
+    const title = this.t(
+      "payment_methods.customer_payment_methods.paypal.title"
+    ).replace("{{ email }}", this.data.attributes.payment_data.email);
+
     return {
       id: this.data.id,
-      title: `Saved Paypal account (${this.data.attributes.payment_data.email})`,
+      title: title,
       value: this.getValue(),
       icon: 'paypal',
       icon_description: 'Paypal'
@@ -56,9 +60,13 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
   }
 
   creditCardRenderContext() {
+    const title = this.t(
+      "payment_methods.customer_payment_methods.credit_card.title"
+    ).replace("{{ last4 }}", this.data.attributes.payment_data.last4);
+
     return {
       id: this.data.id,
-      title: `Saved card ending in ${this.data.attributes.payment_data.last4}`,
+      title: title,
       value: this.getValue(),
       icon: this.data.attributes.payment_data.brand.toLowerCase(),
       icon_description: this.data.attributes.payment_data.brand
@@ -68,7 +76,7 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
   bankTransferRenderContext() {
     return {
       id: this.data.id,
-      title: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.title'),
+      title: this.t('payment_methods.customer_payment_methods.bank_transfer.title'),
       value: this.getValue(),
       icon: '',
       icon_description: ''

--- a/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
+++ b/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
@@ -7,26 +7,16 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
   }
 
   getRenderContext() {
-    let title = null;
-    let icon = null;
-    let icon_description = null;
-
-    if(this.data.attributes.payment_data.last4) {
-      title = `Saved card ending in ${this.data.attributes.payment_data.last4}`;
-      icon = this.data.attributes.payment_data.brand.toLowerCase();
-      icon_description = this.data.attributes.payment_data.brand;
-    } else if(this.data.attributes.payment_data.email) {
-      title = `Saved Paypal account (${this.data.attributes.payment_data.email})`;
-      icon = 'paypal';
-      icon_description = 'Paypal';
-    }
+    if (this.isCreditCard()) return this.creditCardRenderContext();
+    if (this.isPaypal()) return this.paypalRenderContext();
+    if (this.isBankTransfer()) return this.bankTransferRenderContext();
 
     return {
       id: this.data.id,
-      title: title,
+      title: null,
       value: this.getValue(),
-      icon: icon,
-      icon_description: icon_description
+      icon: null,
+      icon_description: null
     }
   }
 
@@ -41,6 +31,48 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
       payment_method_type: null,
       payment_processor: null,
     });
+  }
+
+  isCreditCard() {
+    return !!this.data.attributes.payment_data.last4;
+  }
+
+  isPaypal() {
+    return !!this.data.attributes.payment_data.email;
+  }
+
+  isBankTransfer() {
+    return this.data.attributes.payment_method_type === "bank-transfer";
+  }
+
+  paypalRenderContext() {
+    return {
+      id: this.data.id,
+      title: `Saved Paypal account (${this.data.attributes.payment_data.email})`,
+      value: this.getValue(),
+      icon: 'paypal',
+      icon_description: 'Paypal'
+    };
+  }
+
+  creditCardRenderContext() {
+    return {
+      id: this.data.id,
+      title: `Saved card ending in ${this.data.attributes.payment_data.last4}`,
+      value: this.getValue(),
+      icon: this.data.attributes.payment_data.brand.toLowerCase(),
+      icon_description: this.data.attributes.payment_data.brand
+    };
+  }
+
+  bankTransferRenderContext() {
+    return {
+      id: this.data.id,
+      title: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.title'),
+      value: this.getValue(),
+      icon: '',
+      icon_description: ''
+    };
   }
 
 }

--- a/src/checkout/payment_methods/shop_payment_methods/submarine_bank_transfer_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/submarine_bank_transfer_payment_method.js
@@ -18,7 +18,7 @@ export class SubmarineBankTransferShopPaymentMethod extends ShopPaymentMethod {
       value: this.getValue(),
       subfields_content: this.options.html_templates.submarine_bank_transfer_subfields_content,
       subfields_class: '',
-      icon: 'generic',
+      icon: '',
       icon_description: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.icon_description'),
       submarine_bank_transfer_message_js: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.submarine_bank_transfer_message_js'),
       submarine_bank_transfer_message_no_js: this.t('payment_methods.shop_payment_methods.submarine.bank_transfer.submarine_bank_transfer_message_no_js'),

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -15,33 +15,69 @@ export class SubmarineThankYouStep extends CustardModule {
   }
 
   setup() {
+    this.findPaymentMethodData();
     this.updatePaymentMethodIcon();
   }
 
-  updatePaymentMethodIcon() {
-    this.$paymentIcon = this.$element.find(".payment-icon");
-    this.$paymentIcon.removeClass("payment-icon--generic");
-    this.$paymentIcon.addClass(`payment-icon--${this.iconName()}`);
-  }
-
-  iconName() {
+  findPaymentMethodData() {
     const paymentMethod = this.options.order.attributes._payment_method;
     const allPaymentMethods = [
       ...this.options.submarine.shop_payment_methods.data,
       ...this.options.submarine.customer_payment_methods.data
     ];
-    const [paymentMethodName, paymentMethodId] = paymentMethod.split(/_(?=\d+$)/);
-    const paymentMethodData = allPaymentMethods.find(paymentMethod => {
-      return paymentMethod["type"] === paymentMethodName && Number(paymentMethod["id"]) === Number(paymentMethodId);
+    const [paymentMethodName, paymentMethodId] = paymentMethod.split(
+      /_(?=\d+$)/
+    );
+    this.paymentMethodData = allPaymentMethods.find(paymentMethod => {
+      return (
+        paymentMethod["type"] === paymentMethodName &&
+        Number(paymentMethod["id"]) === Number(paymentMethodId)
+      );
     });
+    this.paymentMethodType = this.paymentMethodData.attributes.payment_method_type;
+  }
 
-    if (paymentMethodData["type"] === "shop_payment_method") {
-      const paymentMethodType = paymentMethodData.attributes.payment_method_type;
-      if (paymentMethodType === "credit-card") return "generic";
-      return paymentMethodType;
-    } else {
-      return paymentMethodData.attributes.payment_data.brand.replace(/\s+/g, "-").toLowerCase();
+  updatePaymentMethodIcon() {
+    this.$paymentIcon = this.$element.find(".payment-icon");
+    if (this.isBankTransfer()) {
+      this.$paymentIcon.replaceWith(`<span>${this.bankTransferTitle()}</span>`);
+
+      return;
     }
+
+    this.$paymentIcon.removeClass("payment-icon--generic");
+    this.$paymentIcon.addClass(`payment-icon--${this.iconName()}`);
+  }
+
+  bankTransferTitle() {
+    return this.options.submarine.translations.payment_methods.shop_payment_methods.submarine.bank_transfer.title;
+  }
+
+  iconName() {
+    if (this.isShopPaymentMethod()) {
+      if (this.isCreditCard()) return "generic";
+      return this.paymentMethodType;
+    }
+
+    return this.cardBrand();
+  }
+
+  isShopPaymentMethod() {
+    return this.paymentMethodData["type"] === "shop_payment_method";
+  }
+
+  isCreditCard() {
+    return this.paymentMethodType === "credit-card";
+  }
+
+  isBankTransfer() {
+    return this.paymentMethodType === 'bank-transfer';
+  }
+
+  cardBrand() {
+    return this.paymentMethodData.attributes.payment_data.brand
+      .replace(/\s+/g, "-")
+      .toLowerCase();
   }
 
 }


### PR DESCRIPTION
Clubhouse: [ch12613](https://app.clubhouse.io/disco/story/12613/client-uat-feedback)

### Description
- Make sure that bank transfer customer payment method has a title instead of `null` and remove card icon from bank transfer shop payment method and customer payment method.
<img width="665" alt="Screen Shot 2020-03-06 at 12 14 54 pm" src="https://user-images.githubusercontent.com/18070175/76041974-aaec2000-5fa7-11ea-8270-ed8a1754e69e.png">

- Show bank transfer text at Thank You page instead of icon for both shop payment method and customer payment method.
<img width="660" alt="Screen Shot 2020-03-06 at 12 12 10 pm" src="https://user-images.githubusercontent.com/18070175/76041987-b0e20100-5fa7-11ea-837c-66dba04d018a.png">

- Make sure credit card icons show properly when card payment method used.

**VISA customer payment method**
<img width="668" alt="Screen Shot 2020-03-06 at 12 13 53 pm" src="https://user-images.githubusercontent.com/18070175/76042013-bc352c80-5fa7-11ea-88c1-dc72a1d1bdac.png">

**Shop payment method**
<img width="655" alt="Screen Shot 2020-03-06 at 12 16 10 pm" src="https://user-images.githubusercontent.com/18070175/76042017-c0614a00-5fa7-11ea-95fb-7cd940abbf6e.png">

- Extract customer payment method titles to language settings such that they can be set like this:
```
  "submarine": {
    "payment_methods": {
      "customer_payment_methods": {
        "credit_card": {
          "title": "Saved card ending in {{ last4 }}"
        },
        "bank_transfer": {
          "title": "代金引換"
        }
      }
    }
  }
```

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.