### PR TITLE
Upgrade custard-js to v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "shopify"
   ],
   "dependencies": {
-    "@discolabs/custard-js": "^0.0.4",
+    "@discolabs/custard-js": "^0.1.0",
     "lodash": "^4.17.15",
     "payform": "^1.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,10 +89,12 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@discolabs/custard-js@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@discolabs/custard-js/-/custard-js-0.0.4.tgz#b4e05335d32487b60ef1d9cc00bd81d6a9a24a54"
-  integrity sha512-nanYIqghQM10fHK2t+UCdWAp6c8W+P+LT9mEkPEic03bPxSeLwkb6JBqxKzP/TpYDMyBYm7s2ncU8mvHkMwtjQ==
+"@discolabs/custard-js@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@discolabs/custard-js/-/custard-js-0.1.0.tgz#c02d7792b98b4ac95f4e8d5e1e0a2b4cdcd896ed"
+  integrity sha512-QZ2kAkAsFRiWABCz6NWun10SR60q8NUmgPJrhOVmHhBB3bpa7SpjkrOPKMqJ48P7KuqHPYrWNTi2MNHt4bhJiA==
+  dependencies:
+    lodash "^4.17.15"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
### Description
- Upgrade custard-js to v0.1.0