### PR TITLE
CH13528: Display valid customer payment methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@discolabs/custard-js": "^0.1.3",
     "lodash": "^4.17.15",
+    "luxon": "^1.23.0",
     "payform": "^1.4.0"
   },
   "devDependencies": {

--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -479,7 +479,7 @@ export class SubmarinePaymentMethodStep extends CustardModule {
       const expiresAtParts = expiresAtISO.split('-');
       const year = Number(expiresAtParts[0]);
       const month = Number(expiresAtParts[1]);
-      const expiresAt = DateTime.fromObject(year, month).endOf('month');
+      const expiresAt = DateTime.fromObject({ year, month }).endOf('month');
       const currentTime = DateTime.local();
 
       return currentTime < expiresAt;

--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -482,7 +482,7 @@ export class SubmarinePaymentMethodStep extends CustardModule {
       const expiresAt = DateTime.fromObject(year, month).endOf('month');
       const currentTime = DateTime.local();
 
-      return currentTime > expiresAt;
+      return currentTime < expiresAt;
     }
 
     return true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,11 @@ lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+luxon@^1.23.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.23.0.tgz#23b748ad0f2d5494dc4d2878c19278c1e651410c"
+  integrity sha512-+6a/bXsCWrrR8vfbL41iM92es12zwV2Rum/KPkT+ubOZnnU3Sqbqok/FmD1xsWlWN2Y9Hu0fU/vNgU24ns7bpA==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"


### PR DESCRIPTION
Clubhouse: [ch13528](https://app.clubhouse.io/disco/story/13528/submarine-js-customisations)

### Description
- It looks like the payment method icons we need (JCB, Elo, UnionPay) are already present and we may not need to do anything to display them. Classnames are `payment-icon--jcb`, `payment-icon--elo` and `payment-icon--unionpay`.
![Screenshot from 2020-04-28 09-29-32](https://user-images.githubusercontent.com/18070175/80430725-d3065880-8932-11ea-9dc6-a4afa6577b45.png)
![Screenshot from 2020-04-28 09-29-13](https://user-images.githubusercontent.com/18070175/80430729-d4d01c00-8932-11ea-99a9-f8cb8318ef8b.png)
![Screenshot from 2020-04-28 09-28-55](https://user-images.githubusercontent.com/18070175/80430730-d568b280-8932-11ea-9f82-509fde5e2286.png)
- Add logic to only show valid cards (not expired) - checks to see if card has expired according to user's timezone (`DateTime.local()`). Ideally, the check would be according to the issuing bank's timezone but we don't have that info so for cases where an expired card still appears, it may be that we still attempt to charge the card but it'll be for the processor/card issuing bank to reject it (see https://stackoverflow.com/questions/1731772/credit-card-expiration-dates-in-which-timezone). 

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.