### PR TITLE
CH13869: address uat feedback

### DIFF
--- a/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
+++ b/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
@@ -1,5 +1,9 @@
 import SubmarinePaymentMethod from '../submarine_payment_method';
 
+const CARD_ICON_CLASS_MAPPINGS = {
+  mastercard: 'master'
+};
+
 export class CustomerPaymentMethod extends SubmarinePaymentMethod {
   getValue() {
     return `customer_payment_method_${this.data.id}`;
@@ -59,7 +63,7 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
       id: this.data.id,
       title: this.creditCardTitle(),
       value: this.getValue(),
-      icon: this.data.attributes.payment_data.brand.toLowerCase(),
+      icon: this.creditCardIcon(),
       icon_description: this.data.attributes.payment_data.brand
     };
   }
@@ -100,5 +104,16 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
           this.data.attributes.payment_data.last4
         )
       : `Saved card ending in ${this.data.attributes.payment_data.last4}`;
+  }
+
+  creditCardIcon() {
+    const brand = this.data.attributes.payment_data.brand
+      .match(/[a-zA-Z ]+/)[0]
+      .toLowerCase()
+      .trim()
+      .split(' ')
+      .join('-');
+
+    return CARD_ICON_CLASS_MAPPINGS[brand] || brand;
   }
 }

--- a/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
+++ b/src/checkout/payment_methods/customer_payment_methods/customer_payment_method.js
@@ -1,8 +1,5 @@
 import SubmarinePaymentMethod from '../submarine_payment_method';
-
-const CARD_ICON_CLASS_MAPPINGS = {
-  mastercard: 'master'
-};
+import { CARD_ICON_CLASS_MAPPINGS } from '../../../constants';
 
 export class CustomerPaymentMethod extends SubmarinePaymentMethod {
   getValue() {
@@ -111,8 +108,7 @@ export class CustomerPaymentMethod extends SubmarinePaymentMethod {
       .match(/[a-zA-Z ]+/)[0]
       .toLowerCase()
       .trim()
-      .split(' ')
-      .join('-');
+      .replace(' ', '-');
 
     return CARD_ICON_CLASS_MAPPINGS[brand] || brand;
   }

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -65,7 +65,8 @@ export class SubmarineThankYouStep extends CustardModule {
   }
 
   iconName() {
-    if (!this.isShopPaymentMethod()) return this.cardIcon();
+    if (!this.isShopPaymentMethod() && this.isCreditCard())
+      return this.cardIcon();
     if (this.isCreditCard()) return 'generic';
 
     return this.paymentMethodType;

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -21,6 +21,7 @@ export class SubmarineThankYouStep extends CustardModule {
   setup() {
     this.findPaymentMethodData();
     this.updatePaymentMethodIcon();
+    this.updateCardLast4();
   }
 
   findPaymentMethodData() {
@@ -50,6 +51,12 @@ export class SubmarineThankYouStep extends CustardModule {
 
     this.$paymentIcon.removeClass('payment-icon--generic');
     this.$paymentIcon.addClass(`payment-icon--${this.iconName()}`);
+  }
+
+  updateCardLast4() {
+    if (!this.isShopPaymentMethod()) {
+      this.$paymentIcon.after(`<span>${this.cardLast4Detail()}</span>`);
+    }
   }
 
   bankTransferTitle() {
@@ -84,5 +91,16 @@ export class SubmarineThankYouStep extends CustardModule {
       .replace(' ', '-');
 
     return CARD_ICON_CLASS_MAPPINGS[brand] || brand;
+  }
+
+  cardLast4Detail() {
+    const { last4 } = this.paymentMethodData.attributes.payment_data;
+    const thankYouTranslations = this.options.submarine.translations.thank_you;
+    const cardLast4Translation =
+      thankYouTranslations && thankYouTranslations.card_last4;
+
+    return cardLast4Translation
+      ? cardLast4Translation.replace('{{ last4 }}', last4)
+      : `ending with ${last4}`;
   }
 }

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -3,6 +3,7 @@ import {
   STEP_THANK_YOU,
   STEP_ORDER_STATUS
 } from '@discolabs/custard-js';
+import { CARD_ICON_CLASS_MAPPINGS } from '../constants';
 
 export class SubmarineThankYouStep extends CustardModule {
   id() {
@@ -57,12 +58,10 @@ export class SubmarineThankYouStep extends CustardModule {
   }
 
   iconName() {
-    if (this.isShopPaymentMethod()) {
-      if (this.isCreditCard()) return 'generic';
-      return this.paymentMethodType;
-    }
+    if (!this.isShopPaymentMethod()) return this.cardIcon();
+    if (this.isCreditCard()) return 'generic';
 
-    return this.cardBrand();
+    return this.paymentMethodType;
   }
 
   isShopPaymentMethod() {
@@ -77,9 +76,13 @@ export class SubmarineThankYouStep extends CustardModule {
     return this.paymentMethodType === 'bank-transfer';
   }
 
-  cardBrand() {
-    return this.paymentMethodData.attributes.payment_data.brand
-      .replace(/\s+/g, '-')
-      .toLowerCase();
+  cardIcon() {
+    const brand = this.paymentMethodData.attributes.payment_data.brand
+      .match(/[a-zA-Z ]+/)[0]
+      .toLowerCase()
+      .trim()
+      .replace(' ', '-');
+
+    return CARD_ICON_CLASS_MAPPINGS[brand] || brand;
   }
 }

--- a/src/checkout/submarine_thank_you_step.js
+++ b/src/checkout/submarine_thank_you_step.js
@@ -54,7 +54,7 @@ export class SubmarineThankYouStep extends CustardModule {
   }
 
   updateCardLast4() {
-    if (!this.isShopPaymentMethod()) {
+    if (!this.isShopPaymentMethod() && this.isCreditCard()) {
       this.$paymentIcon.after(`<span>${this.cardLast4Detail()}</span>`);
     }
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,3 @@
+export const CARD_ICON_CLASS_MAPPINGS = {
+  mastercard: 'master'
+};


### PR DESCRIPTION
Clubhouse: [ch13528](https://app.clubhouse.io/disco/story/13528/submarine-js-customisations)

### Description
- It would appear card icon classes have changed. From memory, the MasterCard icon class used to be `mastercard` and American Express icon `amex`.
- At the moment, all we do to generate card icon classes is convert the brand to lowercase.
- Update brand-to-icon-class generation logic on Payment Method step and Thank You step to work as follows, e.g.:
  - `MasterCard` => `master` (requires a special mapping as the brand is MasterCard)
  - `American Express` => `american-express`
  - `Apple Pay - MasterCard` => `apple-pay`
![Screenshot from 2020-05-06 12-33-17](https://user-images.githubusercontent.com/18070175/81133721-db473f00-8f95-11ea-916c-b153988bdd76.png)
![Screenshot from 2020-05-06 12-32-55](https://user-images.githubusercontent.com/18070175/81133723-dd110280-8f95-11ea-8b3d-5ec91160fe5c.png)
- Add card last4 details to Thank You page
![Screenshot from 2020-05-06 16-20-04](https://user-images.githubusercontent.com/18070175/81144256-0726ec80-8fb7-11ea-902d-7ce7cfc01e83.png)

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.