### PR TITLE
CH14163: Match hosted fields styles with Shopify

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -52,6 +52,7 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
       styles: {
         input: {
           color: '#333333',
+          margin: '-1px 0 0 0',
           'font-size': '14px',
           'font-family':
             '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif'


### PR DESCRIPTION
Clubhouse: [ch14163](https://app.clubhouse.io/disco/story/14163/add-saved-card-toggle-functionality)

### Description
- As we sometimes get requests to implement saved card toggle functionality, it's convenient to have the styling of the Braintree hosted credit card fields match the Shopify Pay ones as closely as possible.
- [Screen recording](https://www.loom.com/share/d9cf98828987468f9f07f4d6505f3e9a)

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.