### PR TITLE
CH14163, CH14397: Allow one-off payments in Submarine

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods/braintree_apple_pay_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_apple_pay_shop_payment_method.js
@@ -96,6 +96,7 @@ export class BraintreeApplePayShopPaymentMethod extends ShopPaymentMethod {
           // eslint-disable-next-line no-undef
           session.completePayment(ApplePaySession.STATUS_SUCCESS);
           success({
+            shop_payment_method_id: this.data.id,
             customer_payment_method_id: null,
             payment_nonce: payload.nonce,
             payment_method_type: 'apple-pay',

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -33,7 +33,7 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
             this.$subfields.addClass(
               'card-fields-container--loaded card-fields-container--transitioned'
             );
-            this.$subfields.find('iframe').css({ height: '18px' });
+            this.$subfields.find('iframe').css({ height: '44px' });
 
             success();
           })
@@ -53,6 +53,7 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
         input: {
           color: '#333333',
           margin: '-1px 0 0 0',
+          padding: '0.94em 0.8em',
           'font-size': '14px',
           'font-family':
             '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif'

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -58,22 +58,7 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
             '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif'
         }
       },
-      fields: {
-        number: {
-          selector: '#braintree-credit-card-card-number',
-          placeholder: this.t('checkout.credit_card.number_placeholder')
-        },
-        expirationDate: {
-          selector: '#braintree-credit-card-expiration-date',
-          placeholder: this.t(
-            'checkout.credit_card.expiration_date_placeholder'
-          )
-        },
-        cvv: {
-          selector: '#braintree-credit-card-cvv',
-          placeholder: this.t('checkout.credit_card.cvv_placeholder')
-        }
-      }
+      fields: this.creditCardFields()
     };
   }
 
@@ -92,6 +77,7 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
     this.hostedFieldsInstance.tokenize((tokenizeError, payload) => {
       if (!tokenizeError) {
         success({
+          shop_payment_method_id: this.data.id,
           customer_payment_method_id: null,
           payment_nonce: payload.nonce,
           payment_method_type: 'credit-card',
@@ -112,13 +98,47 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
         'payment_methods.shop_payment_methods.braintree.credit_card.title'
       ),
       value: this.getValue(),
-      subfields_content: this.options.html_templates
-        .braintree_credit_card_subfields_content,
+      subfields_content: this.subfieldsContent(),
       subfields_class: 'card-fields-container',
       icon: 'generic',
       icon_description: this.t(
         'payment_methods.shop_payment_methods.braintree.credit_card.icon_description'
-      )
+      ),
+      single_use: this.isSingleUse()
     };
+  }
+
+  subfieldsContent() {
+    return this.isSingleUse()
+      ? this.options.html_templates
+          .braintree_credit_card_single_use_subfields_content
+      : this.options.html_templates.braintree_credit_card_subfields_content;
+  }
+
+  creditCardFields() {
+    return {
+      number: {
+        selector: `#braintree-credit-card-card-number${
+          this.isSingleUse() ? '-single-use' : ''
+        }`,
+        placeholder: this.t('checkout.credit_card.number_placeholder')
+      },
+      expirationDate: {
+        selector: `#braintree-credit-card-expiration-date${
+          this.isSingleUse() ? '-single-use' : ''
+        }`,
+        placeholder: this.t('checkout.credit_card.expiration_date_placeholder')
+      },
+      cvv: {
+        selector: `#braintree-credit-card-cvv${
+          this.isSingleUse() ? '-single-use' : ''
+        }`,
+        placeholder: this.t('checkout.credit_card.cvv_placeholder')
+      }
+    };
+  }
+
+  isSingleUse() {
+    return !!this.data.attributes.single_use;
   }
 }

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -1,5 +1,9 @@
 import { ShopPaymentMethod } from './shop_payment_method';
 
+const NUMBER_ERROR = 'Please enter a valid card number';
+const EXPIRATION_DATE_ERROR = 'Please enter a valid expiration date';
+const CVV_ERROR = 'Please enter a valid CVV';
+
 export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
   beforeSetup() {
     this.$subfields = this.$(
@@ -65,13 +69,9 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
   validate() {
     const state = this.hostedFieldsInstance.getState();
-    const errors = [];
-    Object.keys(state.fields).forEach(key => {
-      if (!state.fields[key].isValid) {
-        errors.push(key);
-      }
-    });
-    return errors;
+    return Object.entries(state.fields)
+      .filter(field => !field[1].isValid)
+      .map(field => this.fieldErrors()[field[0]]);
   }
 
   process(success, error) {
@@ -141,5 +141,22 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
   isSingleUse() {
     return !!this.data.attributes.single_use;
+  }
+
+  fieldErrors() {
+    return {
+      expirationDate:
+        this.t(
+          'payment_methods.shop_payment_methods.braintree.credit_card.expiration_date_error'
+        ) || EXPIRATION_DATE_ERROR,
+      cvv:
+        this.t(
+          'payment_methods.shop_payment_methods.braintree.credit_card.cvv_error'
+        ) || CVV_ERROR,
+      number:
+        this.t(
+          'payment_methods.shop_payment_methods.braintree.credit_card.number_error'
+        ) || NUMBER_ERROR
+    };
   }
 }

--- a/src/checkout/payment_methods/shop_payment_methods/cybersource_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/cybersource_credit_card_shop_payment_method.js
@@ -177,6 +177,7 @@ export class CybersourceCreditCardShopPaymentMethod extends ShopPaymentMethod {
     flex.createToken(flexOptions, response => {
       if (!response.error) {
         success({
+          shop_payment_method_id: this.data.id,
           customer_payment_method_id: null,
           payment_nonce: response.token,
           payment_method_type: 'credit-card',

--- a/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/komoju_credit_card_payment_method.js
@@ -7,6 +7,7 @@ export class KomojuCreditCardShopPaymentMethod extends ShopPaymentMethod {
       key: this.data.attributes.publishable_api_key,
       token: token =>
         success({
+          shop_payment_method_id: this.data.id,
           customer_payment_method_id: null,
           payment_nonce: token.id,
           payment_method_type: 'credit-card',

--- a/src/checkout/payment_methods/shop_payment_methods/stripe_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/stripe_credit_card_shop_payment_method.js
@@ -84,6 +84,7 @@ export class StripeCreditCardShopPaymentMethod extends ShopPaymentMethod {
         }
 
         success({
+          shop_payment_method_id: this.data.id,
           customer_payment_method_id: null,
           payment_nonce: result.token.id,
           payment_method_type: 'credit-card',

--- a/src/checkout/payment_methods/shop_payment_methods/submarine_bank_transfer_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/submarine_bank_transfer_payment_method.js
@@ -3,6 +3,7 @@ import { ShopPaymentMethod } from './shop_payment_method';
 export class SubmarineBankTransferShopPaymentMethod extends ShopPaymentMethod {
   process(success) {
     success({
+      shop_payment_method_id: this.data.id,
       customer_payment_method_id: null,
       payment_nonce: null,
       payment_method_type: 'bank-transfer',

--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -356,7 +356,9 @@ export class SubmarinePaymentMethodStep extends CustardModule {
     const validationErrors = selectedPaymentMethod.validate();
     if (validationErrors.length) {
       this.stopLoading();
-      return; // eslint-disable-line consistent-return
+      this.renderErrorNotices(validationErrors);
+
+      return false;
     }
 
     // Perform processing.
@@ -486,5 +488,41 @@ export class SubmarinePaymentMethodStep extends CustardModule {
     }
 
     return true;
+  }
+
+  renderErrorNotices(errors) {
+    const $paymentMethodSectionContent = this.$element.find(
+      '.section__content'
+    );
+    const $existingCardErrorNotices = $paymentMethodSectionContent.find(
+      '.card-input-error-notice'
+    );
+
+    $existingCardErrorNotices.remove();
+    errors
+      .map(error => this.errorNoticeHtml(error).trim())
+      .forEach(errorNoticeHtmlString => {
+        const errorNoticeHtml = this.$.parseHTML(errorNoticeHtmlString);
+        $paymentMethodSectionContent.prepend(this.$(errorNoticeHtml));
+      });
+  }
+
+  errorNoticeHtml(message) {
+    return `
+      <div
+        class="notice notice--error default-background card-input-error-notice"
+        data-banner="true"
+        role="alert"
+        tabindex="-1"
+        aria-atomic="true"
+        aria-live="polite">
+        <svg class="icon-svg icon-svg--size-24 notice__icon" aria-hidden="true" focusable="false">
+          <use xlink:href="#error"></use>
+        </svg>
+        <div class="notice__content">
+          <p class="notice__text">${message}</p>
+        </div>
+      </div>
+    `;
   }
 }


### PR DESCRIPTION
Clubhouse: [ch14163](https://app.clubhouse.io/disco/story/14163/add-saved-card-toggle-functionality), [ch14392](https://app.clubhouse.io/disco/story/14392/allow-one-off-payments-in-submarine)

### Description
**CH14163**
- In response to client's complaint that Shop Pay fields were still differing from our Braintree hosted fields, when I took a closer look, our `.field__input` elements were missing the `.field__input--iframe-container` class which the Shop Pay credit card fields have. After adding that, had to further update the Braintree fields slightly to match the CSS of the Shop Pay fields. This is no longer relevant to Dr Hyman as they don't want Shop Pay anymore. But may be useful for another client in future.

**CH14392**
- Add client-side support for one-off payments in Submarine. 
- Allow 2 sets of Braintree hosted fields to be attached to the DOM. This requires 2 separate sets of input containers with differing `id` attributes. The `id`s for the single-use payment method will have `-single-use` appended to them, e.g. `id="braintree-credit-card-card-number-single-use"`.
- Allow the `shop_payment_method_id` to be passed to Submarine's `preliminary_payment_methods` controller `create` action.
- To add a single-use payment method option, the `single_use` attribute must be set for the payment method in the `submarine.shop_payment_methods` shop metafield:
```
{ 
  id: 33,
  type: "shop_payment_method", 
  attributes: { 
    payment_processor: "braintree", 
    payment_method_type: "credit-card", 
    single_use: true 
  }
}
```
- [Screen recording](https://drive.google.com/file/d/1lVjJDN684szaID9QrftqmqZ_e1gWol3v/view?usp=sharing)

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.