### PR TITLE
CH14397: Handle braintree hosted field errors client

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -65,13 +65,9 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
   validate() {
     const state = this.hostedFieldsInstance.getState();
-    const errors = [];
-    Object.keys(state.fields).forEach(key => {
-      if (!state.fields[key].isValid) {
-        errors.push(key);
-      }
-    });
-    return errors;
+    return Object.entries(state.fields)
+      .filter(field => !field[1].isValid)
+      .map(field => `Please enter a valid ${this.fieldNames()[field[0]]}`);
   }
 
   process(success, error) {
@@ -141,5 +137,22 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
 
   isSingleUse() {
     return !!this.data.attributes.single_use;
+  }
+
+  fieldNames() {
+    return {
+      expirationDate:
+        this.t(
+          'payment_methods.shop_payment_methods.braintree.credit_card.expiration_date'
+        ) || 'expiration date',
+      cvv:
+        this.t(
+          'payment_methods.shop_payment_methods.braintree.credit_card.cvv'
+        ) || 'CVV',
+      number:
+        this.t(
+          'payment_methods.shop_payment_methods.braintree.credit_card.number'
+        ) || 'card number'
+    };
   }
 }

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -1,5 +1,9 @@
 import { ShopPaymentMethod } from './shop_payment_method';
 
+const NUMBER_ERROR = 'Please enter a valid card number';
+const EXPIRATION_DATE_ERROR = 'Please enter a valid expiration date';
+const CVV_ERROR = 'Please enter a valid CVV';
+
 export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
   beforeSetup() {
     this.$subfields = this.$(
@@ -67,7 +71,7 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
     const state = this.hostedFieldsInstance.getState();
     return Object.entries(state.fields)
       .filter(field => !field[1].isValid)
-      .map(field => `Please enter a valid ${this.fieldNames()[field[0]]}`);
+      .map(field => this.fieldErrors()[field[0]]);
   }
 
   process(success, error) {
@@ -139,20 +143,20 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
     return !!this.data.attributes.single_use;
   }
 
-  fieldNames() {
+  fieldErrors() {
     return {
       expirationDate:
         this.t(
-          'payment_methods.shop_payment_methods.braintree.credit_card.expiration_date'
-        ) || 'expiration date',
+          'payment_methods.shop_payment_methods.braintree.credit_card.expiration_date_error'
+        ) || EXPIRATION_DATE_ERROR,
       cvv:
         this.t(
-          'payment_methods.shop_payment_methods.braintree.credit_card.cvv'
-        ) || 'CVV',
+          'payment_methods.shop_payment_methods.braintree.credit_card.cvv_error'
+        ) || CVV_ERROR,
       number:
         this.t(
-          'payment_methods.shop_payment_methods.braintree.credit_card.number'
-        ) || 'card number'
+          'payment_methods.shop_payment_methods.braintree.credit_card.number_error'
+        ) || NUMBER_ERROR
     };
   }
 }

--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -356,7 +356,9 @@ export class SubmarinePaymentMethodStep extends CustardModule {
     const validationErrors = selectedPaymentMethod.validate();
     if (validationErrors.length) {
       this.stopLoading();
-      return; // eslint-disable-line consistent-return
+      this.renderErrorNotices(validationErrors);
+
+      return false;
     }
 
     // Perform processing.
@@ -486,5 +488,41 @@ export class SubmarinePaymentMethodStep extends CustardModule {
     }
 
     return true;
+  }
+
+  renderErrorNotices(errors) {
+    const $paymentMethodSectionContent = this.$element.find(
+      '.section__content'
+    );
+    const $existingCardErrorNotices = $paymentMethodSectionContent.find(
+      '.card-input-error-notice'
+    );
+
+    $existingCardErrorNotices.remove();
+    errors
+      .map(error => this.errorNoticeHtml(error).trim())
+      .forEach(errorNoticeHtmlString => {
+        const errorNoticeHtml = this.$.parseHTML(errorNoticeHtmlString);
+        $paymentMethodSectionContent.prepend(this.$(errorNoticeHtml));
+      });
+  }
+
+  errorNoticeHtml(message) {
+    return `
+      <div
+        class="notice notice--error default-background card-input-error-notice"
+        data-banner="true"
+        role="alert"
+        tabindex="-1"
+        aria-atomic="true"
+        aria-live="polite">
+        <svg class="icon-svg icon-svg--size-24 notice__icon" aria-hidden="true" focusable="false">
+          <use xlink:href="#error"></use>
+        </svg>
+        <div class="notice__content">
+          <p class="notice__text">${message}</p>
+        </div>
+      </div>
+    `;
   }
 }


### PR DESCRIPTION
Clubhouse: [ch14397](https://app.clubhouse.io/disco/story/14397/handle-braintree-hosted-field-errors-client-side)

### Description
- Fix endless loading loop if a customer enters a 3- rather than 4-digit Amex CVV.
- Add immediate error feedback when a customer misses required fields or some input is invalid, e.g. 3- rather than 4-digit CVV entered for Amex cards. Error notices are rendered similar to Shopify's errors. 
- [Demo](https://www.loom.com/share/d11738aed13f4f548233dafd38c9bcec).

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.