### PR TITLE
Tokenize cardholder name

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_credit_card_shop_payment_method.js
@@ -75,21 +75,28 @@ export class BraintreeCreditCardShopPaymentMethod extends ShopPaymentMethod {
   }
 
   process(success, error) {
-    this.hostedFieldsInstance.tokenize((tokenizeError, payload) => {
-      if (!tokenizeError) {
-        success({
-          shop_payment_method_id: this.data.id,
-          customer_payment_method_id: null,
-          payment_nonce: payload.nonce,
-          payment_method_type: 'credit-card',
-          payment_processor: 'braintree'
-        });
-      } else {
-        error({
-          message: null // Braintree's UI will display an appropriate error message.
-        });
+    this.hostedFieldsInstance.tokenize(
+      {
+        cardholderName: this.$(
+          '[name="braintree_hosted_fields_name_on_card"]:visible'
+        ).val()
+      },
+      (tokenizeError, payload) => {
+        if (!tokenizeError) {
+          success({
+            shop_payment_method_id: this.data.id,
+            customer_payment_method_id: null,
+            payment_nonce: payload.nonce,
+            payment_method_type: 'credit-card',
+            payment_processor: 'braintree'
+          });
+        } else {
+          error({
+            message: null // Braintree's UI will display an appropriate error message.
+          });
+        }
       }
-    });
+    );
   }
 
   getRenderContext() {


### PR DESCRIPTION
### Description
- Tokenize cardholder name by passing it as an option to `this.hostedFieldsInstance.tokenize()`
- This helps populate the cardholder name field as shown in the screenshot but not the Braintree customer details, which probably would need to be done Submarine side.
![Screenshot from 2020-06-19 12-22-30](https://user-images.githubusercontent.com/18070175/85090092-9d416a00-b227-11ea-9ab2-37ef7800759e.png)

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.