### PR TITLE
CH16478: support paypal billing agreements

### DIFF
--- a/src/checkout/payment_methods/shop_payment_methods.js
+++ b/src/checkout/payment_methods/shop_payment_methods.js
@@ -1,6 +1,7 @@
 import { ShopPaymentMethod } from './shop_payment_methods/shop_payment_method';
 import { BraintreeCreditCardShopPaymentMethod } from './shop_payment_methods/braintree_credit_card_shop_payment_method';
 import { BraintreeApplePayShopPaymentMethod } from './shop_payment_methods/braintree_apple_pay_shop_payment_method';
+import { BraintreePaypalShopPaymentMethod } from './shop_payment_methods/braintree_paypal_shop_payment_method';
 import { CybersourceCreditCardShopPaymentMethod } from './shop_payment_methods/cybersource_credit_card_shop_payment_method';
 import { StripeCreditCardShopPaymentMethod } from './shop_payment_methods/stripe_credit_card_shop_payment_method';
 import { KomojuCreditCardShopPaymentMethod } from './shop_payment_methods/komoju_credit_card_payment_method';
@@ -9,7 +10,8 @@ import { SubmarineBankTransferShopPaymentMethod } from './shop_payment_methods/s
 const SHOP_PAYMENT_METHODS = {
   braintree: {
     'credit-card': BraintreeCreditCardShopPaymentMethod,
-    'apple-pay': BraintreeApplePayShopPaymentMethod
+    'apple-pay': BraintreeApplePayShopPaymentMethod,
+    'paypal': BraintreePaypalShopPaymentMethod
   },
   cybersource: {
     'credit-card': CybersourceCreditCardShopPaymentMethod

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
@@ -2,7 +2,13 @@ import { ShopPaymentMethod } from './shop_payment_method';
 
 export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
 
-  setup() {
+  beforeSetup() {
+    this.$subfields = this.$(
+      `[data-subfields-for-payment-method="shop_payment_method_${this.data.id}"]`
+    );
+  }
+
+  setup(success, failure) {
     const that = this;
 
     this.deviceData = null;

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
@@ -77,7 +77,7 @@ export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
 
     return this.paypalCheckoutInstance.tokenizePayment(data, (error, payload) => {
       if (error) {
-        that.setError(this.options.translations.paypal_error_unknown);
+        that.setError(this.translations.payment_methods.shop_payment_methods.paypal_error_unknown);
         return;
       }
 
@@ -92,16 +92,16 @@ export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
 
   onError(error) {
     this.billingAgreementNonce = null;
-    this.setError(this.options.translations.paypal_error_unknown);
+    this.setError(this.translations.payment_methods.shop_payment_methods.paypal_error_unknown);
   }
 
   validate() {
     if (!this.paypalButtonReady) {
-      return [this.setError(this.options.translations.paypal_error_not_ready)];
+      return [this.setError(this.translations.payment_methods.shop_payment_methods.paypal_error_not_ready)];
     }
 
     if (!this.billingAgreementNonce) {
-      return [this.setError(this.options.translations.paypal_error_not_approved)];
+      return [this.setError(this.translations.payment_methods.shop_payment_methods.paypal_error_not_approved)];
     }
 
     return [];
@@ -110,14 +110,14 @@ export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
   setError(message) {
     this.$container.removeClass('braintree-paypal--has-success');
     this.$container.toggleClass('braintree-paypal--has-error', !!message);
-    this.$message.text(message || this.options.translations.paypal_instructions);
+    this.$message.text(message || this.translations.payment_methods.shop_payment_methods.paypal.paypal_instructions);
     return message;
   }
 
   setSuccess() {
     this.$container.removeClass('braintree-paypal--has-error');
     this.$container.addClass('braintree-paypal--has-success');
-    this.$message.text(this.options.translations.paypal_success);
+    this.$message.text(this.translations.payment_methods.shop_payment_methods.paypal_success);
   }
 
   process(callbacks) {

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
@@ -138,16 +138,16 @@ export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
     this.$message.text(this.translations.payment_methods.shop_payment_methods.paypal_success);
   }
 
-  process(callbacks) {
+  process(success, error) {
     const that = this;
 
     setTimeout(() => {
       if (!that.billingAgreementNonce) {
-        callbacks.error({
-          message: that.setError(this.options.translations.paypal_error_not_approved)
-        });
+        error(this.options.translations.paypal_error_not_approved);
+        return;
       } else {
-        callbacks.success({
+        success({
+          shop_payment_method_id: this.data.id,
           customer_payment_method_id: null,
           payment_nonce: that.billingAgreementNonce,
           payment_method_type: 'paypal',

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
@@ -1,0 +1,155 @@
+import { ShopPaymentMethod } from './shop_payment_method';
+
+export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
+
+  setup() {
+    const that = this;
+
+    this.deviceData = null;
+    this.paypalButtonReady = false;
+    this.billingAgreementNonce = null;
+
+    this.$container = this.$('#braintree-paypal-container');
+    this.$message = this.$container.find('.braintree-paypal-message');
+
+    submarine.api.generatePaymentProcessorClientToken('braintree', (client_token) => {
+      braintree.client.create({
+        authorization: client_token.attributes.token
+      }, (error, clientInstance) => {
+        that.clientInstance = clientInstance;
+
+        braintree.dataCollector.create({
+          client: clientInstance,
+          paypal: true
+        }, (error, dataCollectorInstance) => {
+          that.deviceData = dataCollectorInstance.deviceData;
+        });
+
+        braintree.paypalCheckout.create({
+          client: clientInstance
+        }, (error, paypalCheckoutInstance) => {
+          that.paypalCheckoutInstance = paypalCheckoutInstance;
+          window.paypalCheckoutInstance = paypalCheckoutInstance;
+
+          paypalCheckoutInstance.loadPayPalSDK({
+            vault: true
+          }, (error) => {
+            paypal.Buttons({
+              fundingSource: paypal.FUNDING.PAYPAL,
+              createBillingAgreement: that.createBillingAgreement.bind(that),
+              onApprove: that.onApprove.bind(that),
+              onCancel: that.onCancel.bind(that),
+              onError: that.onError.bind(that)
+            }).render('#braintree-paypal-mount').then(() => {
+              that.paypalButtonReady = true;
+            });
+          });
+        });
+      });
+    });
+  }
+
+  createBillingAgreement() {
+    const that = this;
+
+    this.setError();
+
+    return this.paypalCheckoutInstance.createPayment({
+      flow: 'vault',
+      billingAgreementDescription: that.options.translations.billing_agreement_description,
+      enableShippingAddress: true,
+      shippingAddressEditable: false,
+      shippingAddressOverride: {
+        recipientName: that.options.shipping_address.name,
+        line1: that.options.shipping_address.address1,
+        line2: that.options.shipping_address.address2,
+        city: that.options.shipping_address.city,
+        countryCode: that.options.shipping_address.country_code,
+        postalCode: that.options.shipping_address.zip,
+        state: that.options.shipping_address.province_code,
+        phone: that.options.shipping_address.phone
+      }
+    });
+  }
+
+  onApprove(data, actions) {
+    const that = this;
+
+    return this.paypalCheckoutInstance.tokenizePayment(data, (error, payload) => {
+      if (error) {
+        that.setError(this.options.translations.paypal_error_unknown);
+        return;
+      }
+
+      that.setSuccess();
+      that.billingAgreementNonce = payload.nonce;
+    });
+  }
+
+  onCancel(data) {
+    this.billingAgreementNonce = null;
+  }
+
+  onError(error) {
+    this.billingAgreementNonce = null;
+    this.setError(this.options.translations.paypal_error_unknown);
+  }
+
+  validate() {
+    if (!this.paypalButtonReady) {
+      return [this.setError(this.options.translations.paypal_error_not_ready)];
+    }
+
+    if (!this.billingAgreementNonce) {
+      return [this.setError(this.options.translations.paypal_error_not_approved)];
+    }
+
+    return [];
+  }
+
+  setError(message) {
+    this.$container.removeClass('braintree-paypal--has-success');
+    this.$container.toggleClass('braintree-paypal--has-error', !!message);
+    this.$message.text(message || this.options.translations.paypal_instructions);
+    return message;
+  }
+
+  setSuccess() {
+    this.$container.removeClass('braintree-paypal--has-error');
+    this.$container.addClass('braintree-paypal--has-success');
+    this.$message.text(this.options.translations.paypal_success);
+  }
+
+  process(callbacks) {
+    const that = this;
+
+    setTimeout(() => {
+      if (!that.billingAgreementNonce) {
+        callbacks.error({
+          message: that.setError(this.options.translations.paypal_error_not_approved)
+        });
+      } else {
+        callbacks.success({
+          customer_payment_method_id: null,
+          payment_nonce: that.billingAgreementNonce,
+          payment_method_type: 'paypal',
+          payment_processor: 'braintree',
+          additional_data: {
+            deviceData: that.deviceData
+          }
+        });
+      }
+    }, 1);
+  }
+
+  getRenderContext(html_templates) {
+    return {
+      id: this.data.id,
+      title: 'Paypal',
+      // subfields_content: renderHtmlTemplate({}, 'braintree_paypal_subfields_content', html_templates),
+      subfields_content: this.options.html_templates.braintree_paypal_subfields_content,
+      icons: 'icons_paypal'
+    }
+  }
+
+}

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
@@ -157,17 +157,17 @@ export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
           }
         });
       }
-    }, 1);
+      });
   }
 
-  getRenderContext(html_templates) {
+  getRenderContext() {
     return {
       id: this.data.id,
       title: 'Paypal',
-      // subfields_content: renderHtmlTemplate({}, 'braintree_paypal_subfields_content', html_templates),
+      value: this.getValue(),
       subfields_content: this.options.html_templates.braintree_paypal_subfields_content,
-      icons: 'icons_paypal'
-    }
+      icon: 'icons_paypal'
+    };
   }
 
 }

--- a/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
+++ b/src/checkout/payment_methods/shop_payment_methods/braintree_paypal_shop_payment_method.js
@@ -56,18 +56,18 @@ export class BraintreePaypalShopPaymentMethod extends ShopPaymentMethod {
 
     return this.paypalCheckoutInstance.createPayment({
       flow: 'vault',
-      billingAgreementDescription: that.options.translations.billing_agreement_description,
+      billingAgreementDescription: that.translations.payment_methods.shop_payment_methods.paypal.paypal_billing_agreement_description,
       enableShippingAddress: true,
       shippingAddressEditable: false,
       shippingAddressOverride: {
-        recipientName: that.options.shipping_address.name,
-        line1: that.options.shipping_address.address1,
-        line2: that.options.shipping_address.address2,
-        city: that.options.shipping_address.city,
-        countryCode: that.options.shipping_address.country_code,
-        postalCode: that.options.shipping_address.zip,
-        state: that.options.shipping_address.province_code,
-        phone: that.options.shipping_address.phone
+        recipientName: that.options.checkout.shipping_address.name,
+        line1: that.options.checkout.shipping_address.address1,
+        line2: that.options.checkout.shipping_address.address2,
+        city: that.options.checkout.shipping_address.city,
+        countryCode: that.options.checkout.shipping_address.country_code,
+        postalCode: that.options.checkout.shipping_address.zip,
+        state: that.options.checkout.shipping_address.province_code,
+        phone: that.options.checkout.shipping_address.phone
       }
     });
   }


### PR DESCRIPTION
Clubhouse: [ch16478](https://app.clubhouse.io/disco/story/16478/support-paypal-billing-agreements)

### Description
- Adding support for Braintree Paypal.
- can be tested using the matching branch on submarine uat theme.
- requires braintree sandbox, linked paypal sandbox and test paypal customer to fully test.

### Checklist
- [ ] Updated README and any other relevant documentation.
- [x] Tested changes on development theme.
- [x] Checked that this PR is referencing the correct base.
- [x] Logged all time in Clockify.