### PR TITLE
CH23248 Assign presentment_currency and presentment_total_price (from checkout) to preliminary_payment_method in submarine-js

### DIFF
--- a/src/checkout/submarine_payment_method_step.js
+++ b/src/checkout/submarine_payment_method_step.js
@@ -421,6 +421,8 @@ export class SubmarinePaymentMethodStep extends CustardModule {
 
   onPaymentMethodProcessingSuccess(payment_method_data) {
     payment_method_data.checkout_id = this.options.checkout.id;
+    payment_method_data.presentment_total_price = this.options.checkout.total_price;
+    payment_method_data.presentment_currency = this.options.checkout.currency;
     payment_method_data.customer_id =
       this.options.customer && this.options.customer.id;
     this.submarine.api.createPreliminaryPaymentMethod(


### PR DESCRIPTION
Clubhouse: [ch23248](https://app.clubhouse.io/disco/story/23248/assign-presentment-currency-and-presentment-total-price-from-checkout-to-preliminary-payment-method-in-submarine-js)

### Description
In order for multicurrency to work, we need to currency that the customer selected to be passed to submarine.

This is only able to be passed in by the shop theme when we create a preliminary payment method.

### Notes
* N/A

### Checklist

- [ ] Updated README and any other relevant documentation.
- [X] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [ ] Updated test matrix.
- [ ] Ensured that Rubocop and friends are happy.
- [X] Checked that this PR is referencing the correct base.
- [X] Logged all time in Clockify.
